### PR TITLE
fix: CREATE_VPC default value as true

### DIFF
--- a/samples/vars.yaml
+++ b/samples/vars.yaml
@@ -1,6 +1,6 @@
 ---
 VARIABLES:
-  - CREATE_VPC: false
+  - CREATE_VPC: true
     APP_ENVIRONMENT: Dev
     APP_NAME: reverse-proxy
     ELB_TYPE: NLB


### PR DESCRIPTION
Matching the CREATE_VPC default value with README.md specification.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
